### PR TITLE
Add iOS app icon generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- **`generateAppIcon` option to generate an Android adaptive app icon.** Set `splashScreen { generateAppIcon = true }` to derive a launcher icon from your existing `logo` and `backgroundColor` — no separate icon assets needed. Generates the adaptive icon (`mipmap-anydpi-v26`, background color + a trimmed, re-centered foreground layer), legacy square/round PNG fallbacks at all five mipmap densities for pre-Android-13 devices, and patches `android:icon`/`android:roundIcon` into the manifest. Off by default.
+- **`generateAppIcon` option to generate the app icon on Android and iOS.** Set `splashScreen { generateAppIcon = true }` to derive a launcher/home-screen icon from your existing `logo` and `backgroundColor` — no separate icon assets needed. On Android, generates the adaptive icon (`mipmap-anydpi-v26`, background color + a trimmed, re-centered foreground layer), legacy square/round PNG fallbacks at all five mipmap densities for pre-Android-13 devices, and patches `android:icon`/`android:roundIcon` into the manifest. On iOS, generates a single 1024×1024 `AppIcon.appiconset` image (Xcode 14+ derives every other required size automatically), composited from `logo` over `backgroundColor`. Off by default on both platforms.
 
 ## 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ splashScreen {
     iosProjectPath = "iosApp/iosApp"                   // Optional: defaults to "iosApp/iosApp"
     androidAppPath = "androidApp"                      // Required if using the new KMP module structure
     resourcePackage = "com.example.myapp.generated.resources"  // Optional: override the inferred Compose resource package
-    generateAppIcon = true                             // Optional: generate an Android adaptive app icon from logo + backgroundColor
+    generateAppIcon = true                             // Optional: generate the app icon (Android + iOS) from logo + backgroundColor
 }
 ```
 
@@ -140,9 +140,9 @@ splashScreen {
 }
 ```
 
-#### Android app icon
+#### App icon (Android + iOS)
 
-Set `generateAppIcon = true` to also generate the Android launcher icon from your existing `logo` and `backgroundColor` — no separate icon assets required:
+Set `generateAppIcon = true` to also generate the app icon on both platforms from your existing `logo` and `backgroundColor` — no separate icon assets required:
 
 ```kotlin
 splashScreen {
@@ -154,11 +154,10 @@ splashScreen {
 
 This requires `logo` to be set, in a rasterizable format (PNG, JPEG, GIF, or BMP — not WebP, `.svg`, or Android vector `.xml`). The plugin generates:
 
-- An adaptive icon (`mipmap-anydpi-v26`) with `backgroundColor` as the background layer and a trimmed, re-centered copy of `logo` as the foreground
-- Legacy square and round PNG fallbacks at all five mipmap densities, for devices below Android 13 (API 26)
-- `android:icon`/`android:roundIcon` in the manifest, pointing at the generated icon
+- **Android:** an adaptive icon (`mipmap-anydpi-v26`) with `backgroundColor` as the background layer and a trimmed, re-centered copy of `logo` as the foreground, legacy square/round PNG fallbacks at all five mipmap densities for devices below Android 13 (API 26), and `android:icon`/`android:roundIcon` in the manifest pointing at the generated icon.
+- **iOS:** a single 1024×1024 `AppIcon.appiconset` image (Xcode 14+ derives every other required size from it automatically), composited from `logo` over `backgroundColor` the same way as Android's legacy fallback icon.
 
-Off by default — changing your app's launcher icon is a visible, home-screen-facing change, so it's opt-in rather than automatic whenever `logo` is set. `backgroundColorNight` and `logoDark` aren't used for the icon: launchers don't resolve dark-mode resource qualifiers for launcher icons.
+Off by default — changing your app's launcher icon is a visible, home-screen-facing change, so it's opt-in rather than automatic whenever `logo` is set. `backgroundColorNight` and `logoDark` aren't used for the icon on either platform: launchers/springboards don't resolve dark-mode resource qualifiers for app icons.
 
 #### ExitAnimation options
 

--- a/plugin/src/main/kotlin/io/kmpbits/splash/AppIconGenerator.kt
+++ b/plugin/src/main/kotlin/io/kmpbits/splash/AppIconGenerator.kt
@@ -23,6 +23,19 @@ internal object AppIconGenerator {
     /** Alpha values at or below this (0-255) are treated as transparent when trimming. */
     private const val ALPHA_TRIM_THRESHOLD = 10
 
+    /** Rasterizable logo file extensions (no dot), accepted for app icon generation on both platforms. */
+    val SUPPORTED_LOGO_EXTENSIONS: Set<String> = setOf("png", "jpg", "jpeg", "gif", "bmp")
+
+    /** Parses a "#RRGGBB" (or "RRGGBB") hex string into an opaque [Color]. */
+    fun parseHexColor(hex: String): Color {
+        val clean = hex.trimStart('#')
+        return Color(
+            clean.substring(0, 2).toInt(16),
+            clean.substring(2, 4).toInt(16),
+            clean.substring(4, 6).toInt(16),
+        )
+    }
+
     /** Legacy (pre-adaptive-icon) launcher icon size in px, keyed by density qualifier. */
     val LEGACY_DENSITIES: Map<String, Int> = mapOf(
         "mdpi" to 48, "hdpi" to 72, "xhdpi" to 96, "xxhdpi" to 144, "xxxhdpi" to 192,

--- a/plugin/src/main/kotlin/io/kmpbits/splash/AppIconGenerator.kt
+++ b/plugin/src/main/kotlin/io/kmpbits/splash/AppIconGenerator.kt
@@ -63,15 +63,23 @@ internal object AppIconGenerator {
     }
 
     /**
-     * True if [trimmedContentPx] (the smaller dimension of a trimmed logo's bounding box) is too
-     * small to fill [FOREGROUND_CONTENT_SCALE] of the largest generated foreground canvas without
-     * visible upscaling.
+     * Convenience overload for Android: true if [trimmedContentPx] is too small to fill
+     * [FOREGROUND_CONTENT_SCALE] of the largest generated foreground canvas without visible
+     * upscaling. Delegates to the general two-argument overload below.
      */
     fun needsUpscalingWarning(trimmedContentPx: Int): Boolean {
         val largestCanvas = FOREGROUND_DENSITIES.values.max()
         val targetContentPx = (largestCanvas * FOREGROUND_CONTENT_SCALE).toInt()
-        return trimmedContentPx < targetContentPx
+        return needsUpscalingWarning(trimmedContentPx, targetContentPx)
     }
+
+    /**
+     * True if [trimmedContentPx] (the smaller dimension of a trimmed logo's bounding box) is
+     * smaller than [targetContentPx] — the content size a specific icon format needs to fill
+     * without visible upscaling.
+     */
+    fun needsUpscalingWarning(trimmedContentPx: Int, targetContentPx: Int): Boolean =
+        trimmedContentPx < targetContentPx
 
     /**
      * Renders the adaptive-icon foreground layer: the trimmed [logo] scaled to

--- a/plugin/src/main/kotlin/io/kmpbits/splash/KmpSplashPlugin.kt
+++ b/plugin/src/main/kotlin/io/kmpbits/splash/KmpSplashPlugin.kt
@@ -92,6 +92,7 @@ class KmpSplashPlugin : Plugin<Project> {
                 )
                 resourcePackage.set(composeResourcePackage(project, ext))
                 exitAnimation.set(ext.exitAnimation)
+                generateAppIcon.set(ext.generateAppIcon)
             }
         )
 

--- a/plugin/src/main/kotlin/io/kmpbits/splash/tasks/GenerateAppIconTask.kt
+++ b/plugin/src/main/kotlin/io/kmpbits/splash/tasks/GenerateAppIconTask.kt
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import java.awt.Color
 import java.awt.image.BufferedImage
 import javax.imageio.ImageIO
 
@@ -43,8 +42,6 @@ abstract class GenerateAppIconTask : DefaultTask() {
     @get:OutputDirectory
     abstract val resOutputDir: DirectoryProperty
 
-    private val supportedExtensions = setOf("png", "jpg", "jpeg", "gif", "bmp")
-
     @TaskAction
     fun generate() {
         if (!enabled.getOrElse(false)) return
@@ -56,10 +53,10 @@ abstract class GenerateAppIconTask : DefaultTask() {
             )
 
         val extension = logoFile.extension.lowercase()
-        if (extension !in supportedExtensions) {
+        if (extension !in AppIconGenerator.SUPPORTED_LOGO_EXTENSIONS) {
             throw org.gradle.api.GradleException(
                 "KmpSplash: 'generateAppIcon' requires logo '${logoFile.name}' to be one of " +
-                "${supportedExtensions.joinToString(", ")}. Vector formats (.svg, Android .xml) " +
+                "${AppIconGenerator.SUPPORTED_LOGO_EXTENSIONS.joinToString(", ")}. Vector formats (.svg, Android .xml) " +
                 "and WebP can't be rasterized for app icon generation."
             )
         }
@@ -77,12 +74,7 @@ abstract class GenerateAppIconTask : DefaultTask() {
             )
         }
 
-        val hexColor = backgroundColor.get().trimStart('#')
-        val background = Color(
-            hexColor.substring(0, 2).toInt(16),
-            hexColor.substring(2, 4).toInt(16),
-            hexColor.substring(4, 6).toInt(16),
-        )
+        val background = AppIconGenerator.parseHexColor(backgroundColor.get())
 
         checkUpscaling(logo)
 

--- a/plugin/src/main/kotlin/io/kmpbits/splash/tasks/GenerateLaunchScreenTask.kt
+++ b/plugin/src/main/kotlin/io/kmpbits/splash/tasks/GenerateLaunchScreenTask.kt
@@ -1,5 +1,6 @@
 package io.kmpbits.splash.tasks
 
+import io.kmpbits.splash.AppIconGenerator
 import io.kmpbits.splash.ExitAnimation
 import io.kmpbits.splash.toKotlinExpression
 import org.gradle.api.DefaultTask
@@ -13,6 +14,9 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import java.awt.Color
+import java.awt.image.BufferedImage
+import javax.imageio.ImageIO
 
 /**
  * Task that generates iOS-specific splash screen resources.
@@ -23,6 +27,8 @@ import org.gradle.api.tasks.TaskAction
  * 3. Patches `Info.plist` to use `UILaunchScreen` with the generated assets.
  * 4. Patches `project.pbxproj` to ensure `Assets.xcassets` is included in the build.
  * 5. Generates `SplashInit.kt` for Compose-side configuration.
+ * 6. When [generateAppIcon] is true, generates a 1024x1024 `AppIcon.appiconset` from the same
+ *    `logo`/`backgroundColor` inputs, overwriting the empty placeholder step 1 always creates.
  */
 abstract class GenerateLaunchScreenTask : DefaultTask() {
 
@@ -60,6 +66,11 @@ abstract class GenerateLaunchScreenTask : DefaultTask() {
     @get:Optional
     abstract val exitAnimation: Property<ExitAnimation>
 
+    /** Whether to also generate a 1024x1024 `AppIcon.appiconset` from `logo`/`backgroundColor`. */
+    @get:Input
+    @get:Optional
+    abstract val generateAppIcon: Property<Boolean>
+
 
     /** Resolved file handle — @Internal so Gradle skips its own (unfriendly) validation. */
     @get:Internal
@@ -81,6 +92,8 @@ abstract class GenerateLaunchScreenTask : DefaultTask() {
     @get:OutputFile
     abstract val pbxprojFile: RegularFileProperty
 
+    private val supportedIconExtensions = setOf("png", "jpg", "jpeg", "gif", "bmp")
+
     @TaskAction
     fun generate() {
         if (!backgroundColor.isPresent) {
@@ -95,6 +108,9 @@ abstract class GenerateLaunchScreenTask : DefaultTask() {
         val resolvedLogoName = copyLogoAssets()
 
         generateColorAsset(resolvedColor)
+        if (generateAppIcon.getOrElse(false)) {
+            generateAppIconAsset(resolvedColor)
+        }
         patchInfoPlist(xcassetsDir.asFile.get().parentFile.resolve("Info.plist"), resolvedLogoName)
         patchProjectPbxproj()
         generateSplashConfig(resolvedColor, resolvedLogoName)
@@ -180,13 +196,78 @@ $lightColorJson$darkColorJson
   ],
   "info": { "author": "xcode", "version": 1 }
 }""".trimIndent())
-        
+
         val appiconset = xcassets.resolve("AppIcon.appiconset")
         if (!appiconset.exists()) {
             appiconset.mkdirs()
             appiconset.resolve("Contents.json").writeText("""{"images":[],"info":{"author":"xcode","version":1}}""")
         }
         logger.lifecycle("KmpSplash: wrote SplashBackground color asset")
+    }
+
+    /**
+     * Generates the iOS "single size" app icon: one fully-opaque 1024x1024 PNG, reusing
+     * [AppIconGenerator.renderLegacy] (the same trim -> scale -> composite-over-background logic
+     * as Android's legacy icon fallback). Xcode 14+ (already this plugin's floor, for
+     * UILaunchScreen) derives every other required size from this one image at build time.
+     *
+     * Always overwrites any existing `AppIcon.appiconset` content once [generateAppIcon] is true,
+     * the same deterministic-overwrite behavior as Android's `android:icon` manifest patching.
+     */
+    private fun generateAppIconAsset(hexColor: String) {
+        val logoFile = logoSourceFile.orNull?.asFile
+            ?: throw GradleException(
+                "KmpSplash: 'generateAppIcon' is enabled but no 'logo' is set in splashScreen { ... }. " +
+                "An app icon requires a logo to derive its foreground from."
+            )
+
+        val extension = logoFile.extension.lowercase()
+        if (extension !in supportedIconExtensions) {
+            throw GradleException(
+                "KmpSplash: 'generateAppIcon' requires logo '${logoFile.name}' to be one of " +
+                "${supportedIconExtensions.joinToString(", ")}. Vector formats (.svg, Android .xml) " +
+                "and WebP can't be rasterized for app icon generation."
+            )
+        }
+
+        val logo = ImageIO.read(logoFile)
+            ?: throw GradleException("KmpSplash: could not decode logo file '${logoFile.absolutePath}' as an image.")
+
+        val clean = hexColor.trimStart('#')
+        val background = Color(
+            clean.substring(0, 2).toInt(16),
+            clean.substring(2, 4).toInt(16),
+            clean.substring(4, 6).toInt(16),
+        )
+
+        checkIconUpscaling(logo)
+
+        val rendered = AppIconGenerator.renderLegacy(logo, background, canvasPx = 1024, round = false)
+        // Apple rejects a submitted icon that carries an alpha channel, even fully opaque —
+        // flatten into a channel-free RGB image before writing.
+        val opaque = BufferedImage(1024, 1024, BufferedImage.TYPE_INT_RGB)
+        val g = opaque.createGraphics()
+        g.drawImage(rendered, 0, 0, null)
+        g.dispose()
+
+        val appiconset = xcassetsDir.asFile.get().resolve("AppIcon.appiconset").also { it.mkdirs() }
+        ImageIO.write(opaque, "png", appiconset.resolve("ic_kmp_app_icon.png"))
+        appiconset.resolve("Contents.json").writeText(
+            """{"images":[{"filename":"ic_kmp_app_icon.png","idiom":"universal","platform":"ios","size":"1024x1024"}],"info":{"author":"xcode","version":1}}"""
+        )
+        logger.lifecycle("KmpSplash: wrote iOS app icon to ${appiconset.absolutePath}")
+    }
+
+    private fun checkIconUpscaling(logo: BufferedImage) {
+        val trimmed = AppIconGenerator.trimTransparentBorder(logo)
+        val smallerDimension = minOf(trimmed.width, trimmed.height)
+        val targetContentPx = (1024 * AppIconGenerator.LEGACY_CONTENT_SCALE).toInt()
+        if (AppIconGenerator.needsUpscalingWarning(smallerDimension, targetContentPx)) {
+            logger.warn(
+                "KmpSplash: logo's trimmed content is ${trimmed.width}x${trimmed.height}px, smaller than " +
+                "ideal for the iOS app icon and will be upscaled. Consider a higher-resolution logo."
+            )
+        }
     }
 
     private fun generateSplashConfig(hexColor: String, logoName: String?) {

--- a/plugin/src/main/kotlin/io/kmpbits/splash/tasks/GenerateLaunchScreenTask.kt
+++ b/plugin/src/main/kotlin/io/kmpbits/splash/tasks/GenerateLaunchScreenTask.kt
@@ -14,7 +14,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import java.awt.Color
 import java.awt.image.BufferedImage
 import javax.imageio.ImageIO
 
@@ -91,8 +90,6 @@ abstract class GenerateLaunchScreenTask : DefaultTask() {
 
     @get:OutputFile
     abstract val pbxprojFile: RegularFileProperty
-
-    private val supportedIconExtensions = setOf("png", "jpg", "jpeg", "gif", "bmp")
 
     @TaskAction
     fun generate() {
@@ -222,10 +219,10 @@ $lightColorJson$darkColorJson
             )
 
         val extension = logoFile.extension.lowercase()
-        if (extension !in supportedIconExtensions) {
+        if (extension !in AppIconGenerator.SUPPORTED_LOGO_EXTENSIONS) {
             throw GradleException(
                 "KmpSplash: 'generateAppIcon' requires logo '${logoFile.name}' to be one of " +
-                "${supportedIconExtensions.joinToString(", ")}. Vector formats (.svg, Android .xml) " +
+                "${AppIconGenerator.SUPPORTED_LOGO_EXTENSIONS.joinToString(", ")}. Vector formats (.svg, Android .xml) " +
                 "and WebP can't be rasterized for app icon generation."
             )
         }
@@ -233,12 +230,7 @@ $lightColorJson$darkColorJson
         val logo = ImageIO.read(logoFile)
             ?: throw GradleException("KmpSplash: could not decode logo file '${logoFile.absolutePath}' as an image.")
 
-        val clean = hexColor.trimStart('#')
-        val background = Color(
-            clean.substring(0, 2).toInt(16),
-            clean.substring(2, 4).toInt(16),
-            clean.substring(4, 6).toInt(16),
-        )
+        val background = AppIconGenerator.parseHexColor(hexColor)
 
         checkIconUpscaling(logo)
 

--- a/plugin/src/test/kotlin/io/kmpbits/splash/AppIconGeneratorTest.kt
+++ b/plugin/src/test/kotlin/io/kmpbits/splash/AppIconGeneratorTest.kt
@@ -90,4 +90,18 @@ class AppIconGeneratorTest {
     fun `needsUpscalingWarning with an explicit target is false when content meets the target`() {
         assertFalse(AppIconGenerator.needsUpscalingWarning(737, targetContentPx = 737))
     }
+
+    @Test
+    fun `parseHexColor parses a hash-prefixed hex string`() {
+        val color = AppIconGenerator.parseHexColor("#FF0000")
+
+        assertEquals(Color(255, 0, 0), color)
+    }
+
+    @Test
+    fun `parseHexColor accepts a hex string without a hash prefix`() {
+        val color = AppIconGenerator.parseHexColor("00FF00")
+
+        assertEquals(Color(0, 255, 0), color)
+    }
 }

--- a/plugin/src/test/kotlin/io/kmpbits/splash/AppIconGeneratorTest.kt
+++ b/plugin/src/test/kotlin/io/kmpbits/splash/AppIconGeneratorTest.kt
@@ -80,4 +80,14 @@ class AppIconGeneratorTest {
         assertEquals(0, legacy.argbAt(0, 0).alpha(), "expected the corner to be clipped outside the circle")
         assertTrue(legacy.argbAt(50, 50).alpha() > 0, "expected the center to remain inside the circle")
     }
+
+    @Test
+    fun `needsUpscalingWarning with an explicit target is true when content is smaller than the target`() {
+        assertTrue(AppIconGenerator.needsUpscalingWarning(500, targetContentPx = 737))
+    }
+
+    @Test
+    fun `needsUpscalingWarning with an explicit target is false when content meets the target`() {
+        assertFalse(AppIconGenerator.needsUpscalingWarning(737, targetContentPx = 737))
+    }
 }

--- a/plugin/src/test/kotlin/io/kmpbits/splash/KmpSplashPluginTest.kt
+++ b/plugin/src/test/kotlin/io/kmpbits/splash/KmpSplashPluginTest.kt
@@ -47,6 +47,18 @@ class KmpSplashPluginTest {
     }
 
     @Test
+    fun `generateAppIcon flag is wired into the generateLaunchScreen task`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("org.jetbrains.kotlin.multiplatform")
+        project.plugins.apply("io.github.kmpbits.splash")
+
+        val ext = project.extensions.getByType(KmpSplashExtension::class.java)
+        ext.generateAppIcon.set(true)
+
+        assertEquals(true, project.generateLaunchScreenTask().generateAppIcon.get())
+    }
+
+    @Test
     fun `ExitAnimation None toKotlinExpression returns null`() {
         kotlin.test.assertNull(ExitAnimation.None.toKotlinExpression())
     }

--- a/plugin/src/test/kotlin/io/kmpbits/splash/tasks/GenerateLaunchScreenTaskTest.kt
+++ b/plugin/src/test/kotlin/io/kmpbits/splash/tasks/GenerateLaunchScreenTaskTest.kt
@@ -1,0 +1,108 @@
+package io.kmpbits.splash.tasks
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GenerateLaunchScreenTaskTest {
+
+    private fun writeTestLogo(file: File) {
+        file.parentFile.mkdirs()
+        val image = BufferedImage(40, 40, BufferedImage.TYPE_INT_ARGB)
+        val g = image.createGraphics()
+        g.color = Color.RED
+        g.fillRect(10, 10, 20, 20)
+        g.dispose()
+        ImageIO.write(image, "png", file)
+    }
+
+    private fun newTask(project: Project): GenerateLaunchScreenTask {
+        val task = project.tasks.create("generateLaunchScreenTest", GenerateLaunchScreenTask::class.java)
+        task.xcassetsDir.set(File(project.projectDir, "iosApp/Assets.xcassets"))
+        task.splashConfigFile.set(File(project.projectDir, "generated/SplashInit.kt"))
+        task.pbxprojFile.set(File(project.projectDir, "iosApp.xcodeproj/project.pbxproj"))
+        return task
+    }
+
+    @Test
+    fun `generates a 1024x1024 opaque icon and single-size Contents-json when enabled`() {
+        val project = ProjectBuilder.builder().build()
+        val task = newTask(project)
+        val logoFile = File(project.projectDir, "logo.png").also { writeTestLogo(it) }
+
+        task.backgroundColor.set("#0000FF")
+        task.logoSourceFile.set(logoFile)
+        task.generateAppIcon.set(true)
+        task.generate()
+
+        val appiconset = File(project.projectDir, "iosApp/Assets.xcassets/AppIcon.appiconset")
+        val iconFile = File(appiconset, "ic_kmp_app_icon.png")
+        assertTrue(iconFile.exists())
+
+        val icon = ImageIO.read(iconFile)
+        assertEquals(1024, icon.width)
+        assertEquals(1024, icon.height)
+        assertFalse(icon.colorModel.hasAlpha(), "expected the generated icon to have no alpha channel")
+
+        val contentsJson = File(appiconset, "Contents.json").readText()
+        assertTrue(contentsJson.contains(""""size":"1024x1024""""))
+        assertTrue(contentsJson.contains(""""filename":"ic_kmp_app_icon.png""""))
+        assertTrue(contentsJson.contains(""""idiom":"universal""""))
+    }
+
+    @Test
+    fun `leaves the empty placeholder untouched when disabled`() {
+        val project = ProjectBuilder.builder().build()
+        val task = newTask(project)
+
+        task.backgroundColor.set("#0000FF")
+        task.generateAppIcon.set(false)
+        task.generate()
+
+        val contentsJson = File(project.projectDir, "iosApp/Assets.xcassets/AppIcon.appiconset/Contents.json")
+        assertTrue(contentsJson.exists())
+        assertEquals("""{"images":[],"info":{"author":"xcode","version":1}}""", contentsJson.readText())
+    }
+
+    @Test
+    fun `fails with an actionable message when enabled but no logo is set`() {
+        val project = ProjectBuilder.builder().build()
+        val task = newTask(project)
+
+        task.backgroundColor.set("#0000FF")
+        task.generateAppIcon.set(true)
+
+        val error = assertFailsWith<GradleException> { task.generate() }
+        assertTrue(error.message!!.contains("no 'logo' is set"), "expected an actionable message, got: ${error.message}")
+    }
+
+    @Test
+    fun `fails with an actionable message for an unsupported logo format`() {
+        val project = ProjectBuilder.builder().build()
+        val task = newTask(project)
+
+        val logoFile = File(project.projectDir, "logo.webp").also {
+            it.parentFile.mkdirs()
+            it.writeBytes(ByteArray(0))
+        }
+
+        task.backgroundColor.set("#0000FF")
+        task.logoSourceFile.set(logoFile)
+        task.generateAppIcon.set(true)
+
+        val error = assertFailsWith<GradleException> { task.generate() }
+        assertTrue(
+            error.message!!.contains("png, jpg, jpeg, gif, bmp"),
+            "expected the supported formats to be listed, got: ${error.message}"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Extends `splashScreen { generateAppIcon = true }` (previously Android-only) to also generate the iOS app icon: a single 1024×1024 opaque PNG plus its `Contents.json`, written into the `AppIcon.appiconset` folder `GenerateLaunchScreenTask` already manages — no new asset fields or DSL properties.
- Reuses `AppIconGenerator.renderLegacy` (built for the Android feature) unchanged; Xcode 14+ (already this plugin's floor) derives every other required icon size from the single 1024×1024 source at build time.
- Extracted the shared logo-format/hex-color parsing logic (previously duplicated between the Android and iOS tasks) into `AppIconGenerator`.
- Off by default; zero behavior change for existing users who don't opt in.

## Test plan
- [x] `./gradlew -p plugin test` — full suite passes, no regressions
- [x] New/extended unit tests for `AppIconGenerator` (generalized `needsUpscalingWarning`, shared `parseHexColor`)
- [x] New `GenerateLaunchScreenTaskTest` (1024×1024/no-alpha icon + Contents.json when enabled, placeholder untouched when disabled, missing-logo error, unsupported-format error)
- [x] Extended `KmpSplashPluginTest` confirming `generateAppIcon` wiring into the iOS task
- [ ] Manual sanity check in Xcode/Simulator (optional, requires a local Xcode environment)